### PR TITLE
improve emagnet_iconnection function and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ This project is licensed under the GNU General Public License v3.0 - see the [LI
 
 ### Notice
 
-Attacking different kinds of accounts via Emagnet that you have not been granted permission to attack is strictly prohibited and it breaks the law. The punishment is grave and you can even get into prison in some countries just for trying to attack for intrusion. That said, it's *important* that all users are aware of this and when you have cloned or downloaded the repo it's fully up to you to take responsibility for your actions. wuseman cannot be held responsible for the actions of any user, all users using Emagnet do so at their own responsibility. 
+Attacking different kinds of accounts via Emagnet that you have not been granted permission to attack is strictly prohibited and it breaks the law. The punishment is grave and you can even get into prison in some countries just for trying to attack for intrusion. That said, it's *important* that all users are aware of this and when you have cloned or downloaded the repository it's fully up to you to take responsibility for your actions. Wuseman cannot be held responsible for the actions of any user, all users using Emagnet do so at their own responsibility. 
 
 Developer: "All my previews where a brute force attack has been done is under controlling forms with 100% fully permissions by the owners. If you have any questions about this then you are welcome to contact me or the owner."
 

--- a/emagnet.sh
+++ b/emagnet.sh
@@ -276,11 +276,10 @@ emagnet_clear() {
 
 #### Check for a working connection, using google since it is up 24/7 
 emagnet_iconnection() {
-    ping -i "1" -c 1 google.com &> /dev/null
-        if [[ "$?" -gt "0" ]]; then 
-            echo -e "$basename$0: internal error -- this feature require a internet connection but you seems to be offline, exiting.."
-            exit 1
-        fi
+   if ! nc -zw1 google.com 443; then
+	   echo -e "$basename$0: internal error -- this feature requires an internet connection but you seem to be offline, exiting.."
+	   exit 1
+	fi
 }
 
 emagnet_optional(){ 


### PR DESCRIPTION
* make `emagnet_iconnection` faster by using `nc` instead of `ping` (benchmarked, approx. 0.024 seconds faster)
by emitting a packet to google.com at port 443 and using a 1 second timeout
* fix typos in README.md